### PR TITLE
fix: ISSUE-6: Publish CLI to NPM to make it available to users

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,31 @@
+name: Publish CLI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://registry.npmjs.org/"
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Build CLI
+        run: npm run build --workspace "@genxapi/cli"
+      - name: Publish CLI
+        run: npm publish --workspace "@genxapi/cli" --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/release-checklist-cli.md
+++ b/docs/release-checklist-cli.md
@@ -1,0 +1,45 @@
+# CLI Release Checklist
+
+## Prerequisites
+
+- Confirm the npm org/user owns `@genxapi/cli` and the name is available.
+- Decide on publishing auth:
+  - Trusted publishing (recommended): configure npm to trust this GitHub repo.
+  - Token fallback: add `NPM_TOKEN` as a GitHub Actions secret.
+
+## Local dry run
+
+```bash
+npm run build --workspace "@genxapi/cli"
+npm pack --workspace "@genxapi/cli" --dry-run
+npm publish --workspace "@genxapi/cli" --dry-run --access public
+```
+
+## Version + tag
+
+```bash
+npm version patch --workspace "@genxapi/cli"
+# or edit packages/cli/package.json manually
+
+git push
+git push --tags
+```
+
+Alternatively, create an explicit tag:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+## CI publish
+
+Pushing a `v*` tag triggers the publish workflow and releases `@genxapi/cli`.
+
+## Post-publish validation
+
+```bash
+npx @genxapi/cli --help
+```
+
+Note: `npx genxapi --help` is only expected if the unscoped `genxapi` package is also published separately.

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
         "access": "restricted"
       },
       "@genxapi/cli": {
-        "registry": "https://npm.pkg.github.com",
-        "access": "restricted"
+        "registry": "https://registry.npmjs.org/",
+        "access": "public"
       }
     }
   },

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -82,17 +82,12 @@ Run `npm run typecheck` at the repository root to validate both packages before 
 ### Publishing the CLI
 
 ```bash
-# Default npm publish (public access)
-npm run npm-publish --workspace @genxapi/cli
-
-# Explicit public publish
-npm run publish:npm-public --workspace @genxapi/cli
-
-# GitHub Packages
-npm run publish:github --workspace @genxapi/cli
+# Build + publish to npmjs.org (public)
+npm run build --workspace @genxapi/cli
+npm publish --workspace @genxapi/cli --access public
 ```
 
-Publishing to GitHub Packages requires a PAT with `read:packages` and `write:packages` scopes.
+Publishing to GitHub Packages is optional; include `--registry https://npm.pkg.github.com` and use a PAT with `read:packages` and `write:packages` scopes.
 
 ### Installing from GitHub Packages
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.1",
   "description": "GenxAPI CLI — Automate, orchestrate, and publish SDKs — faster.",
   "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "type": "module",
   "bin": {
     "genxapi": "./bin/genxapi.js"
@@ -23,14 +26,15 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "publishConfig": {
-    "access": "restricted",
-    "registry": "https://npm.pkg.github.com"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
     "build": "rollup -c",
     "clean": "rimraf dist",
     "lint": "eslint 'src/**/*.ts'",
     "prebuild": "npm run clean",
+    "prepack": "npm run build",
     "test": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
## Changelog

- ISSUE-6: Publish CLI to NPM to make it available to users

## Considerations

- We want to publish the CLI to allow usage through NPX
- We want to document the process and in the future great a GitHub Action on the marketplace for automation