### PR TITLE
chore: Force latest publish

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@genxapi/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "GenxAPI CLI — Automate, orchestrate, and publish SDKs — faster.",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Changelog

- Force the latest publish to allow the set tag to latest on 0.1.9